### PR TITLE
fix circle ci build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: go get -v
+          command: go get -v -d -t
 
       - run:
           name: Run Unit Tests


### PR DESCRIPTION
By adding "-t" flag to go get also the testing dependencies will be fetched